### PR TITLE
Update Dark.VisualStudio2019.vstheme

### DIFF
--- a/src/Dark.VisualStudio2019.vstheme
+++ b/src/Dark.VisualStudio2019.vstheme
@@ -1206,7 +1206,7 @@
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="inline hints">
-        <Background Type="CT_INVALID" Source="00000000" />
+        <Background Type="CT_RAW" Source="FF39393B" />
         <Foreground Type="CT_INVALID" Source="00000000" />
       </Color>
       <Color Name="Inline Rename Field Text">


### PR DESCRIPTION
Fix background color for inline hints.
Default color is too bright and does not match VS 2019 color.