### PR TITLE
Fix StatusBannerWarning readability

### DIFF
--- a/src/Dark.VisualStudio2019.vstheme
+++ b/src/Dark.VisualStudio2019.vstheme
@@ -2923,6 +2923,13 @@
       <Color Name="PageBackground">
         <Background Type="CT_RAW" Source="FF000000" />
       </Color>
+      <Color Name="StatusBannerWarning">
+        <Background Type="CT_RAW" Source="FF433519" />
+        <Foreground Type="CT_RAW" Source="FFFCE100" />
+      </Color>
+      <Color Name="StatusBannerWarningBorder">
+        <Foreground Type="CT_RAW" Source="FFFCE100" />
+      </Color>
     </Category>
     <Category Name="CommonDocumentCard" GUID="{2e129498-0d2d-43ca-94d6-c652c0132543}">
       <Color Name="CardIllustrationFill1">


### PR DESCRIPTION
I added a missing color to fix a readability problem in a warning message (in the publish screen).

Previous version:
![immagine](https://github.com/madskristensen/DarkTheme2019/assets/4757146/e6c09eb1-e88e-4152-b61c-48fdf5c95e6e)

New version:
![immagine](https://github.com/madskristensen/DarkTheme2019/assets/4757146/1801848d-6dea-4e7b-9b04-63158241b1b0)
